### PR TITLE
container class styled for mobile

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -14,6 +14,12 @@
   padding: 0px;
 }
 
+.container {
+  width: 375px;
+  margin: 0 auto;
+  padding: 32px 0;
+}
+
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;


### PR DESCRIPTION
Added .container with width styles into styles.css. This will shrink all containers globally to 375px so media queries must by styled for web and tablet as to their widths respectively